### PR TITLE
update set_toolchain_generation function

### DIFF
--- a/bin/submit_build.py
+++ b/bin/submit_build.py
@@ -174,9 +174,8 @@ def main():
         job['langcode'] = 'C'
 
     # Set target toolchain generation
-    job['tc_gen'] = set_toolchain_generation(easyconfig, user_toolchain=opts.options.toolchain)
+    job['tc_gen'] = set_toolchain_generation(easyconfig, tc_gen=opts.options.toolchain)
     if not job['tc_gen']:
-        logger.error("Unable to determine the toolchain generation, specify it with --toolchain")
         sys.exit(1)
 
     ebconf['subdir-modules'] = os.path.join('modules', job['tc_gen'])

--- a/src/build_tools/package.py
+++ b/src/build_tools/package.py
@@ -16,7 +16,7 @@ Package information of build_tools
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '3.2.3'
+VERSION = '3.3.0'
 
 AUTHOR = {
     'wp': 'Ward Poelmans',

--- a/src/build_tools/softinstall.py
+++ b/src/build_tools/softinstall.py
@@ -72,7 +72,7 @@ def set_toolchain_generation(easyconfig, tc_gen=None):
     name = config_dict['name']
     version = config_dict['version']
     name_version = {'name': name, 'version': version}
-    print(toolchain, name_version)
+    logger.debug('toolchain=%s, name,version=%s', toolchain, name_version)
 
     global SUPPORTED_FULL_TCS
     if not SUPPORTED_FULL_TCS:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,6 @@ Unit tests configuration file
 import os
 import pytest
 
-from build_tools import softinstall
-
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -53,8 +51,3 @@ def realpath_apps_brussel(path):
 @pytest.fixture
 def mock_realpath_apps_brussel(monkeypatch):
     monkeypatch.setattr('os.path.realpath', realpath_apps_brussel)
-
-
-@pytest.fixture
-def mock_supported_tcgens(monkeypatch):
-    monkeypatch.setattr(softinstall, 'SUPPORTED_TCGENS', ['2022a', '2023a'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import pytest
 
 from build_tools import softinstall
 
+
 def pytest_addoption(parser):
     parser.addoption(
         '--fromsource', action='store_true', help='run the tests on the source tree without installing first')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ Unit tests configuration file
 import os
 import pytest
 
+from build_tools import softinstall
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -51,3 +52,8 @@ def realpath_apps_brussel(path):
 @pytest.fixture
 def mock_realpath_apps_brussel(monkeypatch):
     monkeypatch.setattr('os.path.realpath', realpath_apps_brussel)
+
+
+@pytest.fixture
+def mock_supported_tcgens(monkeypatch):
+    monkeypatch.setattr(softinstall, 'SUPPORTED_TCGENS', ['2022a', '2023a'])

--- a/tests/test_softinstall.py
+++ b/tests/test_softinstall.py
@@ -48,7 +48,7 @@ from build_tools import softinstall
         ('fosscuda-2020b.eb', None, False),
     ],
 )
-def test_set_toolchain_generation(toolchain, mock_supported_tcgens):
+def test_set_toolchain_generation(toolchain):
     easyconfig, user_toolchain, expected_generation = toolchain
 
     generation = softinstall.set_toolchain_generation(easyconfig, tc_gen=user_toolchain)

--- a/tests/test_softinstall.py
+++ b/tests/test_softinstall.py
@@ -47,7 +47,6 @@ from build_tools import softinstall
         ('torchvision-0.9.1-fosscuda-2020b-PyTorch-1.8.1.eb', None, False),
         ('fosscuda-2020b.eb', None, False),
     ],
-
 )
 def test_set_toolchain_generation(toolchain, mock_supported_tcgens):
     easyconfig, user_toolchain, expected_generation = toolchain

--- a/tests/test_softinstall.py
+++ b/tests/test_softinstall.py
@@ -47,8 +47,9 @@ from build_tools import softinstall
         ('torchvision-0.9.1-fosscuda-2020b-PyTorch-1.8.1.eb', None, False),
         ('fosscuda-2020b.eb', None, False),
     ],
+
 )
-def test_set_toolchain_generation(toolchain):
+def test_set_toolchain_generation(toolchain, mock_supported_tcgens):
     easyconfig, user_toolchain, expected_generation = toolchain
 
     generation = softinstall.set_toolchain_generation(easyconfig, tc_gen=user_toolchain)

--- a/tests/test_softinstall.py
+++ b/tests/test_softinstall.py
@@ -40,11 +40,12 @@ from build_tools import softinstall
         ('foss-2021a.eb', None, False),
         ('PyTorch-2.1.2-foss-2023a-CUDA-12.1.1.eb', None, '2023a'),
         ('R-4.3.2-gfbf-2023a.eb', None, '2023a'),
-        # system toolchains
+        # system toolchain
         ('zlib-1.2.11.eb', None, '2023a'),
         ('MATLAB-2023b.eb', None, '2023a'),
-        # disallowed toolchains
+        # unsupported toolchains
         ('torchvision-0.9.1-fosscuda-2020b-PyTorch-1.8.1.eb', None, False),
+        ('fosscuda-2020b.eb', None, False),
     ],
 )
 def test_set_toolchain_generation(toolchain):

--- a/tests/test_softinstall.py
+++ b/tests/test_softinstall.py
@@ -25,22 +25,32 @@ from build_tools import softinstall
 @pytest.mark.parametrize(
     'toolchain',
     [
-        ('GCCcore-10.2.0.eb', False, '2020b'),
-        ('GCCcore-10.2.0.eb', '2020b', '2020b'),
-        ('GCCcore-10.2.0.eb', '1920c', False),
-        ('UCX-1.8.0-GCCcore-9.3.0-CUDA-11.0.2.eb', False, '2020a'),
-        ('R-4.0.3-foss-2020b.eb', False, '2020b'),
-        ('R-4.0.3-foss-2020b.eb', '2019a', '2019a'),
-        ('TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb', False, '2020a'),
-        ('TensorFlow-2.3.1-fosscuda-2020a-Python-3.8.2.eb', False, '2020a'),
-        ('SAMtools-1.9-GCC-8.2.0-2.31.1.eb', False, '2019a'),
-        ('SAMtools-1.9-iccifort-2019.1.144-GCC-8.2.0-2.31.1.eb', False, '2019a'),
+        # user-specified generation
+        ('GCCcore-11.3.0.eb', '2022a', '2022a'),
+        ('GCCcore-11.3.0.eb', '2021b', False),
+        ('R-4.3.2-gfbf-2023a.eb', '2022a', '2022a'),
+        # toolchains with custom version
+        ('GCCcore-11.3.0.eb', None, '2022a'),
+        ('GCCcore-10.2.0.eb', None, False),
+        ('UCX-CUDA-1.14.1-GCCcore-12.3.0-CUDA-12.1.1.eb', None, '2023a'),
+        ('bwa-mem2-2.2.1-intel-compilers-2023.1.0.eb', None, '2023a'),
+        ('SAMtools-1.18-GCC-12.3.0.eb', None, '2023a'),
+        # toolchains with generation as their version
+        ('foss-2023a.eb', None, '2023a'),
+        ('foss-2021a.eb', None, False),
+        ('PyTorch-2.1.2-foss-2023a-CUDA-12.1.1.eb', None, '2023a'),
+        ('R-4.3.2-gfbf-2023a.eb', None, '2023a'),
+        # system toolchains
+        ('zlib-1.2.11.eb', None, '2023a'),
+        ('MATLAB-2023b.eb', None, '2023a'),
+        # disallowed toolchains
+        ('torchvision-0.9.1-fosscuda-2020b-PyTorch-1.8.1.eb', None, False),
     ],
 )
 def test_set_toolchain_generation(toolchain):
     easyconfig, user_toolchain, expected_generation = toolchain
 
-    generation = softinstall.set_toolchain_generation(easyconfig, user_toolchain=user_toolchain)
+    generation = softinstall.set_toolchain_generation(easyconfig, tc_gen=user_toolchain)
 
     assert generation == expected_generation
 


### PR DESCRIPTION
EDIT: setting to draft, needs changes as we will set the generation in a hook

fixes [AB#22973](https://dev.azure.com/VUB-ICT/3e951b95-f932-4cd3-9681-259422e2c681/_workitems/edit/22973)

improvements for working with the bot: avoid having to specify the generation as much as possible, and avoid that people from other institutions install unwanted/exotic toolchains.

- make toolchain-version determination more robust and accurate
- return False if the generation is too old or new, or if the toolchain is ~banned~ not supported
- use the latest allowed generation if ~the toolchain-version cannot be determined (assume SYSTEM toolchain)~ system toolchain
