### PR TITLE
set empty MODULEPATH on installation jobs

### DIFF
--- a/src/build_tools/jobtemplate.py
+++ b/src/build_tools/jobtemplate.py
@@ -37,6 +37,7 @@ source "$$VSC_SCRATCH_VO_USER/EB5/eb5env/bin/activate"
 # set environment
 export BUILD_TOOLS_LOAD_DUMMY_MODULES=1
 export LANG=${langcode}
+export MODULEPATH=""  # EB prepends 'modules/collection' to MODULEPATH
 
 SUBDIR_MODULES="modules"
 SUBDIR_MODULES_BWRAP=".modules_bwrap"

--- a/src/build_tools/package.py
+++ b/src/build_tools/package.py
@@ -16,7 +16,7 @@ Package information of build_tools
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '4.1.0'
+VERSION = '4.1.1'
 
 AUTHOR = {
     'wp': 'Ward Poelmans',

--- a/tests/input/build_job_01.sh
+++ b/tests/input/build_job_01.sh
@@ -14,6 +14,7 @@ source "$VSC_SCRATCH_VO_USER/EB5/eb5env/bin/activate"
 # set environment
 export BUILD_TOOLS_LOAD_DUMMY_MODULES=1
 export LANG=C
+export MODULEPATH=""  # EB prepends 'modules/collection' to MODULEPATH
 
 SUBDIR_MODULES="modules"
 SUBDIR_MODULES_BWRAP=".modules_bwrap"

--- a/tests/input/build_job_02.sh
+++ b/tests/input/build_job_02.sh
@@ -14,6 +14,7 @@ source "$VSC_SCRATCH_VO_USER/EB5/eb5env/bin/activate"
 # set environment
 export BUILD_TOOLS_LOAD_DUMMY_MODULES=1
 export LANG=C
+export MODULEPATH=""  # EB prepends 'modules/collection' to MODULEPATH
 
 SUBDIR_MODULES="modules"
 SUBDIR_MODULES_BWRAP=".modules_bwrap"


### PR DESCRIPTION
Easybuild prepends `modules/collection` to `MODULEPATH` because we pass it as `--suffix-modules-path=collection`. Therefore, there is no need to also have the folders _per-year_ in `MODULEPATH`, given that `collection` contains all module files already. This duplication of paths in `MODULEPATH` heavily slows down `lmod` commands during installation.