### PR TITLE
use bvasp6 autogroup for VASP-6

### DIFF
--- a/src/build_tools/hooks_hydra.py
+++ b/src/build_tools/hooks_hydra.py
@@ -53,7 +53,7 @@ SOFTWARE_GROUPS = {
     'QuantumATK': 'bquantumatk',
     'ReaxFF': 'breaxff',
     'Stata': 'brusselall',  # site license
-    'VASP': 'bvasp',
+    'VASP': {'6': 'bvasp6', '5': 'bvasp'},
 }
 
 GPU_ARCHS = [x for (x, y) in ARCHS.items() if y['partition']['gpu']]
@@ -247,7 +247,13 @@ def parse_hook(ec, *args, **kwargs):  # pylint: disable=unused-argument
         ec.log.info(f"[parse hook] Set parameter postinstallcmds: {ec['postinstallcmds']}")
 
     if ec.name in SOFTWARE_GROUPS:
-        ec['group'] = SOFTWARE_GROUPS[ec.name]
+        if isinstance(SOFTWARE_GROUPS[ec.name], str):
+            ec['group'] = SOFTWARE_GROUPS[ec.name]
+        else:
+            for versionsuffix, group in SOFTWARE_GROUPS[ec.name].items():
+                if ec.version.startswith(versionsuffix):
+                    ec['group'] = group
+                    break
         ec.log.info(f"[parse hook] Set parameter group: {ec['group']}")
 
     # set optarch for intel compilers on AMD nodes

--- a/src/build_tools/hooks_hydra.py
+++ b/src/build_tools/hooks_hydra.py
@@ -250,8 +250,8 @@ def parse_hook(ec, *args, **kwargs):  # pylint: disable=unused-argument
         if isinstance(SOFTWARE_GROUPS[ec.name], str):
             ec['group'] = SOFTWARE_GROUPS[ec.name]
         else:
-            for versionsuffix, group in SOFTWARE_GROUPS[ec.name].items():
-                if ec.version.startswith(versionsuffix):
+            for version, group in SOFTWARE_GROUPS[ec.name].items():
+                if ec.version.startswith(version):
                     ec['group'] = group
                     break
         ec.log.info(f"[parse hook] Set parameter group: {ec['group']}")

--- a/src/build_tools/package.py
+++ b/src/build_tools/package.py
@@ -16,7 +16,7 @@ Package information of build_tools
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '4.1.3'
+VERSION = '4.1.4'
 
 AUTHOR = {
     'wp': 'Ward Poelmans',


### PR DESCRIPTION
VASP licenses are tied to the major version.