### PR TITLE
remove cpu_architecture for BLIS on zen5

### DIFF
--- a/src/build_tools/hooks_hydra.py
+++ b/src/build_tools/hooks_hydra.py
@@ -411,10 +411,6 @@ def pre_configure_hook(self, *args, **kwargs):  # pylint: disable=unused-argumen
         self.cfg['install_type'] = 'merge'
         self.log.info("[pre-configure hook] Set install_type to %s for bwrap", self.cfg['install_type'])
 
-    # BLIS autodetection fails on zen5, set to zen3 (the highest currently supported zen)
-    if self.name == 'BLIS' and LOCAL_ARCH == 'zen5' and LooseVersion(self.version) <= LooseVersion('2.0'):
-        self.cfg['cpu_architecture'] = 'zen3'
-
     # PMIx settings:
     # - build with munge support to work with Slurm
     # - disable per-user configuration files to save disk accesses during job start-up

--- a/src/build_tools/package.py
+++ b/src/build_tools/package.py
@@ -16,7 +16,7 @@ Package information of build_tools
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '4.4.0'
+VERSION = '4.4.1'
 
 AUTHOR = {
     'wp': 'Ward Poelmans',


### PR DESCRIPTION
no longer necessary now that https://github.com/easybuilders/easybuild-easyblocks/pull/4034 is merged

[AB#28172](https://dev.azure.com/VUB-ICT/3e951b95-f932-4cd3-9681-259422e2c681/_workitems/edit/28172)