### PR TITLE
set license group in pre-module hook

### DIFF
--- a/src/build_tools/hooks_hydra.py
+++ b/src/build_tools/hooks_hydra.py
@@ -169,9 +169,9 @@ def get_group(name, version):
         if isinstance(SOFTWARE_GROUPS[name], str):
             group = SOFTWARE_GROUPS[name]
         else:
-            for regex, grp in SOFTWARE_GROUPS[name].items():
+            for regex, groupname in SOFTWARE_GROUPS[name].items():
                 if re.search(regex, version):
-                    group = grp
+                    group = groupname
                     break
             if group is None:
                 raise EasyBuildError(f"No group defined for version {version} of licensed software {name}")

--- a/src/build_tools/hooks_hydra.py
+++ b/src/build_tools/hooks_hydra.py
@@ -17,6 +17,7 @@ Custom EasyBuild hooks for VUB-HPC Clusters
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
+import grp
 import json
 import os
 import re
@@ -61,7 +62,7 @@ SOFTWARE_GROUPS = {
     'QuantumATK': 'bquantumatk',
     'ReaxFF': 'breaxff',
     'Stata': 'brusselall',  # site license
-    'VASP': {r'^6\.': 'bvasp6', r'^5\.': 'bvasp'},
+    'VASP': {r'^6\.': 'bvasp6', r'^5\.': 'bvasp'},  # bvasp6 is an autogroup (bvasp, ...)
 }
 
 GPU_ARCHS = [x for (x, y) in ARCHS[MACHINE].items() if y['partition']['gpu']]
@@ -366,11 +367,6 @@ def parse_hook(ec, *args, **kwargs):  # pylint: disable=unused-argument
         ec['postinstallcmds'] = [f'ln -sfb {ec["license_file"]} %(installdir)s/licenses/']
         ec.log.info(f"[parse hook] Set parameter postinstallcmds: {ec['postinstallcmds']}")
 
-    group = get_group(ec.name, ec.version)
-    if group:
-        ec['group'] = group
-        ec.log.info(f"[parse hook] Set parameter group: {ec['group']}")
-
     # set optarch for intel compilers on AMD nodes
     optarchs_intel = {
         'zen2': '-march=core-avx2',
@@ -485,6 +481,16 @@ def pre_module_hook(self, *args, **kwargs):  # pylint: disable=unused-argument
     # Must be done this way, updating self.cfg['modextravars']
     # directly doesn't work due to templating.
     with self.cfg.disable_templating():
+
+        ##########################
+        # ---- PERMISSIONS ----- #
+        ##########################
+
+        group = get_group(self.name, self.version)
+        if group:
+            group_id = grp.getgrnam(group).gr_gid
+            self.group = (group, group_id)
+            self.log.info(f"[pre-module hook] Set group to: {self.group}")
 
         ##########################
         # ------ MPI ----------- #

--- a/src/build_tools/hooks_hydra.py
+++ b/src/build_tools/hooks_hydra.py
@@ -62,7 +62,7 @@ SOFTWARE_GROUPS = {
     'QuantumATK': 'bquantumatk',
     'ReaxFF': 'breaxff',
     'Stata': 'brusselall',  # site license
-    'VASP': {r'^6\.': 'bvasp6', r'^5\.': 'bvasp'},  # bvasp6 is an autogroup (bvasp, ...)
+    'VASP': {r'^6\.': 'bli_vasp6', r'^5\.': 'bvasp'},  # bli_vasp6 is an autogroup (bvasp6->bvasp, g_vasp6, avasp6)
 }
 
 GPU_ARCHS = [x for (x, y) in ARCHS[MACHINE].items() if y['partition']['gpu']]

--- a/src/build_tools/package.py
+++ b/src/build_tools/package.py
@@ -16,7 +16,7 @@ Package information of build_tools
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '4.5.1'
+VERSION = '4.5.2'
 
 AUTHOR = {
     'wp': 'Ward Poelmans',

--- a/src/build_tools/package.py
+++ b/src/build_tools/package.py
@@ -16,7 +16,7 @@ Package information of build_tools
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '4.5.0'
+VERSION = '4.5.1'
 
 AUTHOR = {
     'wp': 'Ward Poelmans',


### PR DESCRIPTION
set the group in the `pre_module_hook` instead of the `parse` hook.

this avoids that the license group has to be the primary group when installing, while still adding the group check in the module file, and also setting the group permissions because the `permissions` step comes after the `module` step.

this may still fail in cases where the license group really has to be the primary group during building/installing, but i expect that to be exceptional cases, and that won't work in sofia in any case.

[AB#29942](https://dev.azure.com/VUB-ICT/3e951b95-f932-4cd3-9681-259422e2c681/_workitems/edit/29942)